### PR TITLE
refactor: simplify database client configuration by using DATABASE_URL

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -21,11 +21,7 @@ async function query(text, params) {
 
 async function getNewClient() {
   const client = new Client({
-    host: process.env.POSTGRES_HOST,
-    port: process.env.POSTGRES_PORT,
-    user: process.env.POSTGRES_USER,
-    database: process.env.POSTGRES_DB,
-    password: process.env.POSTGRES_PASSWORD,
+    connectionString: process.env.DATABASE_URL,
     ssl: process.env.NODE_ENV === "production" ? true : false,
   });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,12 @@
 const nextJest = require("next/jest");
 const dotenv = require("dotenv");
+const dotenvExpand = require("dotenv-expand");
 
-dotenv.config({
+const myEnv = dotenv.config({
   path: ".env.development",
 });
+
+dotenvExpand.expand(myEnv);
 
 const createJestConfig = nextJest({
   dir: ".",


### PR DESCRIPTION
- Use lib `dotenv-expand` for the process of Jest get `DATABASE_URL`.
- Use the enviroment variable on `database.js`.